### PR TITLE
Quick Fix Discord link

### DIFF
--- a/src/site/_includes/components/join-the-movement.njk
+++ b/src/site/_includes/components/join-the-movement.njk
@@ -8,7 +8,7 @@
   <div class="lg:w-2/3 mx-auto md:grid md:grid-cols-2 md:gap-6 lg:gap-8">
     {{ zinger.cta(
         "Join the Discord",
-        "https://discord.gg",
+        "https://discord.gg/jamstack",
         "bg-gradient-card-sunrise card-shadow hover:card-shadow-sunrise",
         "#logo-discord"
         )


### PR DESCRIPTION
Quick Fix Discord link in "Join the movement section"
It was pointed to discord homepage instead of jamstack channel.